### PR TITLE
Class names should match File names for autoloading.

### DIFF
--- a/src/Console/Commands/AllKeysCommand.php
+++ b/src/Console/Commands/AllKeysCommand.php
@@ -5,7 +5,7 @@ use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
-class AllKeys extends Command {
+class AllKeysCommand extends Command {
 
     /**
      * The console command name.

--- a/src/Console/Commands/AnalyzeLocaleCommand.php
+++ b/src/Console/Commands/AnalyzeLocaleCommand.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
-class AnalyzeLocale extends Command {
+class AnalyzeLocaleCommand extends Command {
 
 	/**
 	 * The console command name.

--- a/src/Console/Commands/InvalidCommand.php
+++ b/src/Console/Commands/InvalidCommand.php
@@ -5,7 +5,7 @@ use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
-class Invalid extends Command {
+class InvalidCommand extends Command {
 
 	/**
 	 * The console command name.

--- a/src/Console/Commands/UntranslatedCommand.php
+++ b/src/Console/Commands/UntranslatedCommand.php
@@ -4,7 +4,7 @@ namespace RobinFranssen\AnalyzeLocale\Console\Commands;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 
-class Untranslated extends Command {
+class UntranslatedCommand extends Command {
 
 	/**
 	 * The console command name.

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 namespace RobinFranssen\AnalyzeLocale\Providers;
 
-use RobinFranssen\AnalyzeLocale\Console\Commands\AllKeys;
-use RobinFranssen\AnalyzeLocale\Console\Commands\AnalyzeLocale;
-use RobinFranssen\AnalyzeLocale\Console\Commands\Invalid;
-use RobinFranssen\AnalyzeLocale\Console\Commands\Untranslated;
+use RobinFranssen\AnalyzeLocale\Console\Commands\AllKeysCommand;
+use RobinFranssen\AnalyzeLocale\Console\Commands\AnalyzeLocaleCommand;
+use RobinFranssen\AnalyzeLocale\Console\Commands\InvalidCommand;
+use RobinFranssen\AnalyzeLocale\Console\Commands\UntranslatedCommand;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -12,25 +12,25 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->app['command.locale.scan'] = $this->app->share(
             function () {
-                return new AnalyzeLocale;
+                return new AnalyzeLocaleCommand();
             }
         );
 
         $this->app['command.locale.allkeys'] = $this->app->share(
             function () {
-                return new AllKeys();
+                return new AllKeysCommand();
             }
         );
 
         $this->app['command.locale.untranslated'] = $this->app->share(
             function () {
-                return new Untranslated();
+                return new UntranslatedCommand();
             }
         );
 
         $this->app['command.locale.invalid'] = $this->app->share(
             function () {
-                return new Invalid();
+                return new InvalidCommand();
             }
         );
 


### PR DESCRIPTION
An issue currently is the PSR autoload doesn't find the Commands since their file name and their class names don't match.

This PR fixes that.
